### PR TITLE
Add literal map type support.

### DIFF
--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -20,7 +20,8 @@ defmodule StreamDataTypes do
 
   ## Shrinking(TODO(njichev))
   """
-  def from_type(module, name, args \\ []) when is_atom(module) and is_atom(name) and is_list(args) do
+  def from_type(module, name, args \\ [])
+      when is_atom(module) and is_atom(name) and is_list(args) do
     type = for pair = {^name, _type} <- beam_types(module), do: pair
 
     # pick correct type, when multiple
@@ -107,7 +108,7 @@ defmodule StreamDataTypes do
   end
 
   defp generate({:type, _, :non_neg_integer, _}) do
-    map(integer(), &(abs(&1)))
+    map(integer(), &abs(&1))
   end
 
   defp generate({:type, _, :float, _}) do
@@ -140,9 +141,9 @@ defmodule StreamDataTypes do
   defp generate_map_field({:type, _, :map_field_exact, [key, value]}) do
     map_of(
       generate(key),
-      generate(value)
+      generate(value),
+      min_length: 1
     )
-    |> filter(&(&1 != %{}))
   end
 
   defp generate_map_field({:type, _, :map_field_assoc, [key, value]}) do
@@ -150,5 +151,5 @@ defmodule StreamDataTypes do
       generate(key),
       generate(value)
     )
- end
+  end
 end

--- a/test/stream_data/types_list.ex
+++ b/test/stream_data/types_list.ex
@@ -7,4 +7,12 @@ defmodule StreamDataTest.TypesList do
   @type basic_neg_integer() :: neg_integer()
   @type basic_non_neg_integer() :: non_neg_integer()
   @type basic_pos_integer() :: pos_integer()
+
+  ## Literals
+  # Map
+  @type literal_empty_map() :: %{}
+  @type literal_map_with_key() :: %{:key => integer()}
+  @type literal_map_with_required_key() :: %{required(float()) => integer()}
+  @type literal_map_with_optional_key() :: %{optional(float()) => integer()}
+  @type literal_map_with_required_and_optional_key() :: %{:key => integer(), optional(float()) => integer()}
 end

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -78,6 +78,64 @@ defmodule StreamData.TypesTest do
     end
   end
 
+  describe "literals" do
+    test "empty map" do
+      data = generate_data(:literal_empty_map)
+
+      check all x <- data do
+        assert x == %{}
+      end
+    end
+
+    test "map with fixed key" do
+      data = generate_data(:literal_map_with_key)
+
+      check all x <- data, max_runs: 25 do
+        assert is_map(x)
+        %{key: int} = x
+        assert is_integer(int)
+      end
+    end
+
+    test "map with optional key" do
+      data = generate_data(:literal_map_with_optional_key)
+
+      check all x <- data, max_runs: 25 do
+        assert is_map(x)
+
+        assert Map.keys(x) |> Enum.all?(fn k -> is_float(k) end)
+        assert Map.values(x) |> Enum.all?(fn v -> is_integer(v) end)
+      end
+    end
+
+    test "map with required keys" do
+      data = generate_data(:literal_map_with_required_key)
+
+      check all x <- data, max_runs: 25 do
+        assert is_map(x)
+        assert x != %{}
+
+        assert Map.keys(x) |> Enum.all?(fn k -> is_float(k) end)
+        assert Map.values(x) |> Enum.all?(fn v -> is_integer(v) end)
+      end
+    end
+
+    test "map with required and optional key" do
+      data = generate_data(:literal_map_with_required_and_optional_key)
+
+      check all x <- data, max_runs: 25 do
+        assert is_map(x)
+
+        %{key: int} = x
+        map = Map.delete(x, :key)
+        assert is_integer(int)
+
+        assert Map.keys(map) |> Enum.all?(fn k -> is_float(k) end)
+        assert Map.values(map) |> Enum.all?(fn v -> is_integer(v) end)
+      end
+    end
+  end
+
   defp generate_data(name, args \\ []) do
     Types.from_type(StreamDataTest.TypesList, name, args)
   end


### PR DESCRIPTION
Generate map generators for every key type: required/optional,
then merge them into one generator.