### PR TITLE
Raise on protocols.

### DIFF
--- a/test/stream_data/types_list.ex
+++ b/test/stream_data/types_list.ex
@@ -90,4 +90,8 @@ defmodule StreamDataTest.TypesList do
   ## Nested Lists
   @type nested_list_type :: list(list(integer()))
   @type nested_nonempty_list_type :: nonempty_list(list(integer()))
+
+  ## Protocol Types
+  @type protocol_enumerable :: Enumerable.t()
+  @type protocol_enum :: Enumerable.t()
 end

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -7,7 +7,7 @@ defmodule StreamData.TypesTest do
   test "raises when missing a type" do
     assert_raise(
       ArgumentError,
-      "Module StreamDataTest.TypesList does not define type does_not_exist/0.\n",
+      "Module StreamDataTest.TypesList does not define type does_not_exist/0.",
       fn -> generate_data(:does_not_exist) end
     )
   end
@@ -566,6 +566,30 @@ defmodule StreamData.TypesTest do
     end
   end
 
+  describe "protocols" do
+    test "protocols are not to be generated" do
+      assert_raise(
+        ArgumentError,
+        """
+        You have specified a type which relies or is the protocol #{Enumerable}.
+        Protocols are currently unsupported, instead try generating for the type which implements the protocol.
+        """,
+        fn -> generate_data(:protocol_enumerable) end
+      )
+    end
+
+    test "types that expand to protocols are not to be generated" do
+      assert_raise(
+        ArgumentError,
+        """
+        You have specified a type which relies or is the protocol #{Enumerable}.
+        Protocols are currently unsupported, instead try generating for the type which implements the protocol.
+        """,
+        fn -> generate_data(:protocol_enum) end
+      )
+    end
+  end
+
   defp each_improper_list([], _head_fun, _tail_fun), do: :ok
 
   defp each_improper_list([elem], _head_fun, tail_fun) do
@@ -593,10 +617,7 @@ defmodule StreamData.TypesTest do
   defp is_iolist([x | xs]) when is_binary(x), do: is_iolist(xs)
 
   defp is_iolist([x | xs]) do
-    case is_iolist(x) do
-      true -> is_iolist(xs)
-      _ -> false
-    end
+    is_iolist(x) && is_iolist(xs)
   end
 
   defp is_iolist(_), do: false


### PR DESCRIPTION
The Protocol type(for example Enumerable.t) expands to term/0.
This is not very useful for the user, hence just tell the user to
use the data which implements the protocol as a generator.

This also includes types which will eventually expand to a Protocol,
for example Enum.t is defined as Enumerable.t.