### PR TITLE
Raise on pid/port types.

### DIFF
--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -107,6 +107,20 @@ defmodule StreamDataTypes do
     raise ArgumentError, "Cannot generate types of the none type."
   end
 
+  defp generate({:type, _, type, _}) when type in [:pid, :port] do
+    raise ArgumentError, """
+    Pid/Port types are not supported.
+    To create a StreamData generator for pids/ports use the following hack:
+        pids = StreamData.map(
+          StreamData.constant(:unused),
+          fn _ -> spawn_pid/port() end
+        )
+
+    You can specify any zero arity function for spawning pids/ports.
+    To have multiple types of pids, chain them together with `StreamData.one_of/1`
+    """
+  end
+
   defp generate({:type, _, :integer, _}) do
     integer()
   end

--- a/test/stream_data/types_list.ex
+++ b/test/stream_data/types_list.ex
@@ -11,6 +11,8 @@ defmodule StreamDataTest.TypesList do
   @type basic_tuple() :: tuple()
   @type basic_map :: map()
   @type basic_struct :: struct()
+  @type basic_pid :: pid()
+  @type basic_port :: port()
 
   # Numbers
   @type basic_float() :: float()

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -87,6 +87,22 @@ defmodule StreamData.TypesTest do
       end
     end
 
+    test "pid" do
+      assert_raise(
+        ArgumentError,
+        ~r/Pid\/Port types are not supported./,
+        fn -> generate_data(:basic_pid) end
+      )
+    end
+
+    test "port" do
+      assert_raise(
+        ArgumentError,
+        ~r/Pid\/Port types are not supported./,
+        fn -> generate_data(:basic_port) end
+      )
+    end
+
     # Numbers
     test "float" do
       data = generate_data(:basic_float)


### PR DESCRIPTION
You cannot generate okay pids that respond to a user's select messages,
hence raise when they try to do this.
Also add a solution on how to achieve what they want in the error
message.