### PR TITLE
Add support for types with parameters.

### DIFF
--- a/test/stream_data/types_list.ex
+++ b/test/stream_data/types_list.ex
@@ -138,4 +138,5 @@ defmodule StreamDataTest.TypesList do
   @type parameterized_dict(key, value) :: list({key, value})
   @type parameterized_recursive_tuple(a) :: nil | {a, parameterized_recursive_tuple(a)}
   @type parameterized_recursive_forest(a) :: {a, [parameterized_recursive_forest(a)]}
+  @type parameterized_keyword(a) :: Keyword.t(a)
 end

--- a/test/stream_data/types_list.ex
+++ b/test/stream_data/types_list.ex
@@ -113,7 +113,8 @@ defmodule StreamDataTest.TypesList do
   @type recursive_tuple :: nil | {integer(), recursive_tuple()}
 
   @typep operator :: :+ | :- | :* | :/
-  @type recursive_expression :: integer() | {recursive_expression(), operator(), recursive_expression()}
+  @type recursive_expression ::
+          integer() | {recursive_expression(), operator(), recursive_expression()}
 
   @typep zero :: :zero
   @type recursive_integers :: zero | %{succ: recursive_integers}
@@ -127,5 +128,14 @@ defmodule StreamDataTest.TypesList do
 
   ## Protocol Types
   @type protocol_enumerable :: Enumerable.t()
-  @type protocol_enum :: Enumerable.t()
+  @type protocol_enum :: Enum.t()
+
+  ## Parameterized Types
+  @type parameterized_simple(a) :: a
+  @type parameterized_list(a) :: list(a)
+  @type parameterized_tuple(a, b, c) :: {a, b, c}
+  @type parameterized_map(a) :: %{key: a}
+  @type parameterized_dict(key, value) :: list({key, value})
+  @type parameterized_recursive_tuple(a) :: nil | {a, parameterized_recursive_tuple(a)}
+  @type parameterized_recursive_forest(a) :: {a, [parameterized_recursive_forest(a)]}
 end

--- a/test/stream_data/types_list.ex
+++ b/test/stream_data/types_list.ex
@@ -126,11 +126,15 @@ defmodule StreamDataTest.TypesList do
           optional(:forests) => recursive_map_forest()
         }
 
-  ## Protocol Types
+  ## Remote types
+  @type remote_string :: String.t()
+  @type remote_keyword_list :: Keyword.t(integer())
+
+  ## Protocol types
   @type protocol_enumerable :: Enumerable.t()
   @type protocol_enum :: Enum.t()
 
-  ## Parameterized Types
+  ## Parameterized types
   @type parameterized_simple(a) :: a
   @type parameterized_list(a) :: list(a)
   @type parameterized_tuple(a, b, c) :: {a, b, c}

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -888,6 +888,45 @@ defmodule StreamData.TypesTest do
         assert is_forest(x)
       end
     end
+
+    test "using remote types as arguments" do
+      data = generate_data(:parameterized_simple, remote_type: {String, :t})
+
+      check all x <- data do
+        assert is_binary(x)
+      end
+    end
+
+    test "using parameterized remote types" do
+      data = generate_data(:parameterized_keyword, [:float])
+
+      check all x <- data do
+        assert is_list(x)
+
+        Enum.each(x, fn {atom, float} ->
+          assert is_atom(atom)
+          assert is_float(float)
+        end)
+      end
+    end
+
+    test "using parameterized remote types with remote type arguments" do
+      data = generate_data(:parameterized_keyword, remote_type: {Keyword, :t, [:integer]})
+
+      check all x <- data, max_runs: 25 do
+        assert is_list(x)
+
+        Enum.each(x, fn {atom, keyword_list} ->
+          assert is_atom(atom)
+          assert is_list(keyword_list)
+
+          Enum.each(keyword_list, fn {atom, integer} ->
+            assert is_atom(atom)
+            assert is_integer(integer)
+          end)
+        end)
+      end
+    end
   end
 
   defp is_forest({x, forests}) when is_integer(x) and is_list(forests) do


### PR DESCRIPTION
This will let people generate stream data generators for generalized
types such as `@type my_type(a) :: list(a)`

The arguments passed in to `from_type` should be a list of the following:
  - any basic type(:integer, :atom, etc.)
  - literal: (1 | 2 | :my_atom | [](empty list) | {} | %{})
  - list: [arguments]
  - tuple: [arguments]
  - map: [{key, value}, {:optional, {key, value}}]
  - user_type: user_type_name(user types are other types defined in the same module)
  - remote_type: {ModuleName, type_name} | {ModuleName, type_name, [arguments]}

Every time a type variable is seen in the type AST, it will be expanded
to a normal type. This also removes the need for arguments to be passed
in.

This also opens up the work for remote types to be done easy.
Remote types already have their arguments expanded, so when working with
remote types with arguments, we can just pass in their arguments to
from_type and don't expand them since that's already done.