### PR TITLE
Add type validations for random types.

### DIFF
--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -61,21 +61,37 @@ defmodule StreamDataTypes do
   """
   def from_type(module, name, args \\ [])
       when is_atom(module) and is_atom(name) and is_list(args) do
-    validate_arguments(args)
+    validate_generators(args)
 
     pick_type_from_beam(module, name, args)
     |> inline_type_parameters(args)
     |> inline_user_type(module)
-    |> generate_from_type
+    |> generate_from_type()
+  end
+
+  def from_type_with_validator(module, name, args \\ [])
+      when is_atom(module) and is_atom(name) and is_list(args) do
+    validate_arguments(args)
+
+    {
+      from_type(module, name, Enum.map(args, &elem(&1, 0))),
+      type_validator_for(module, name, Enum.map(args, &elem(&1, 1)))
+    }
+  end
+
+  def type_validator_for(module, name, args \\ [])
+      when is_atom(module) and is_atom(name) and is_list(args) do
+    validate_functions(args)
+
+    pick_type_from_beam(module, name, args)
+    |> inline_type_parameters(args)
+    |> inline_user_type(module)
+    |> validator_for()
   end
 
   defp pick_type_from_beam(module, name, args) do
     type = for pair = {^name, _type} <- beam_types(module), do: pair
 
-    # pick correct type, when multiple
-    # Validate outer is list/map/tuple when having args
-    # Convert args
-    # put args in type tuple
     case type do
       [] ->
         raise ArgumentError,
@@ -137,15 +153,41 @@ defmodule StreamDataTypes do
 
   defp vars(_), do: 0
 
-  defp validate_arguments([]), do: :ok
-  defp validate_arguments([%StreamData{} | rest]), do: validate_arguments(rest)
+  defp validate_generators([]), do: :ok
+  defp validate_generators([%StreamData{} | rest]), do: validate_generators(rest)
 
-  defp validate_arguments(argument) do
+  defp validate_generators(argument) do
     raise ArgumentError, """
     Expected a StreamData generator, got #{inspect(argument)}.
 
     Try passing in a list of StreamData generators:
         - from_type(YourModule, function_name, [StreamData.integer()])
+    """
+  end
+
+  defp validate_functions([]), do: :ok
+  defp validate_functions([fun | rest]) when is_function(fun, 1), do: validate_functions(rest)
+
+  defp validate_functions(argument) do
+    raise ArgumentError, """
+    Expected a member function, got #{inspect(argument)}.
+
+    Try passing in a list of member functions:
+        - validator_from_type(YourModule, type_name, [&is_integer/1])
+    """
+  end
+
+  defp validate_arguments([]), do: :ok
+
+  defp validate_arguments([{%StreamData{}, fun} | rest]) when is_function(fun, 1),
+    do: validate_arguments(rest)
+
+  defp validate_arguments(argument) do
+    raise ArgumentError, """
+    Expected a StreamData generator, got #{inspect(argument)}.
+
+    Try passing in a list of tuples of StreamData generators and type member functions:
+        - from_type(YourModule, type_name, [{StreamData.integer(), &is_integer/1}])
     """
   end
 
@@ -569,14 +611,6 @@ defmodule StreamDataTypes do
     generate_union(args)
   end
 
-  defp char() do
-    integer(0..0x10FFFF)
-  end
-
-  defp non_negative_integer() do
-    map(integer(), &abs/1)
-  end
-
   defp generate_map_field({:type, _, :map_field_exact, [{_, _, key}, value]}) do
     value = generate(value)
 
@@ -596,6 +630,390 @@ defmodule StreamDataTypes do
       generate(key),
       generate(value)
     )
+  end
+
+  # Handle recursive/unions here
+  defp validator_for({name, {:type, _, :union, args}}) do
+    {nodes, leaves} = nodes_and_leaves(name, args)
+
+    is_leaf =
+      Enum.map(leaves, &validator_for_type/1)
+      |> is_one_of()
+
+    case nodes do
+      [] ->
+        is_leaf
+
+      nodes ->
+        validator_for_recursive(nodes, is_leaf)
+    end
+  end
+
+  defp validator_for({name, type}) do
+    if recursive_without_union?(type, name) do
+      is_leaf =
+        rewrite_recursive_type(type, name)
+        |> validator_for_type
+
+      validator_for_recursive([type], is_leaf)
+    else
+      validator_for_type(type)
+    end
+  end
+
+  defp validator_for_recursive(nodes, is_leaf) do
+    is_node = fn member ->
+      fn term ->
+        if is_leaf.(term) do
+          true
+        else
+          is_node =
+            nodes
+            |> Enum.map(&map_user_type_to_is_node(&1, member))
+            |> Enum.map(&validator_for_type(&1))
+            |> is_one_of
+
+          is_node.(term)
+        end
+      end
+    end
+
+    is_node.(is_node)
+  end
+
+  defp map_user_type_to_is_node({:user_type, _line, _name, _args}, is_node), do: is_node
+
+  defp map_user_type_to_is_node({:type, line, type, args}, is_node) do
+    args = Enum.map(args, &map_user_type_to_is_node(&1, is_node))
+    {:type, line, type, args}
+  end
+
+  defp map_user_type_to_is_node({_, _, _l} = type, _is_node), do: type
+
+  defp map_user_type_to_is_node(is_node, _leaf) when is_function(is_node, 1), do: is_node
+
+  defp validator_for_type(validator) when is_function(validator, 1) do
+    validator
+  end
+
+  defp validator_for_type({:type, _, type, _}) when type in [:any, :term] do
+    fn _x -> true end
+  end
+
+  defp validator_for_type({:type, _, :atom, _}) do
+    &is_atom/1
+  end
+
+  defp validator_for_type({:type, _, type, _}) when type in [:none, :no_return] do
+    # TODO
+  end
+
+  defp validator_for_type({:type, _, type, _}) when type in [:pid, :port] do
+    # TODO
+  end
+
+  defp validator_for_type({:type, _, :integer, _}) do
+    &is_integer/1
+  end
+
+  defp validator_for_type({:type, _, :pos_integer, _}) do
+    compose([&is_integer/1, &(&1 > 0)])
+  end
+
+  defp validator_for_type({:type, _, :neg_integer, _}) do
+    compose([&is_integer/1, &(&1 < 0)])
+  end
+
+  defp validator_for_type({:type, _, :non_neg_integer, _}) do
+    compose([&is_integer/1, &(&1 >= 0)])
+  end
+
+  defp validator_for_type({:type, _, :float, _}) do
+    &is_float/1
+  end
+
+  defp validator_for_type({:type, _, :reference, _}) do
+    &is_reference/1
+  end
+
+  defp validator_for_type({:type, _, :tuple, :any}) do
+    &is_tuple/1
+  end
+
+  defp validator_for_type({:type, _, :tuple, []}) do
+    &(&1 == {})
+  end
+
+  defp validator_for_type({:type, _, :tuple, types}) do
+    validators =
+      types
+      |> Enum.map(&validator_for_type/1)
+
+    tuple_element_count = length(validators)
+
+    fn
+      x when is_tuple(x) and tuple_size(x) == tuple_element_count ->
+        x
+        |> Tuple.to_list()
+        |> Enum.zip(validators)
+        |> Enum.all?(fn {member, fun} ->
+          fun.(member)
+        end)
+
+      _ ->
+        false
+    end
+  end
+
+  defp validator_for_type({:type, _, :list, []}) do
+    &is_list/1
+  end
+
+  defp validator_for_type({:type, _, :list, [type]}) do
+    member = validator_for_type(type)
+
+    &(is_list(&1) && Enum.all?(&1, member))
+  end
+
+  defp validator_for_type({:type, _, nil, []}) do
+    &(&1 === [])
+  end
+
+  defp validator_for_type({:type, _, :nonempty_list, []}) do
+    compose([&(&1 != []), &is_list/1])
+  end
+
+  defp validator_for_type({:type, _, :nonempty_list, [type]}) do
+    member = validator_for_type(type)
+
+    &(&1 != [] && is_list(&1) && Enum.all?(&1, member))
+  end
+
+  defp validator_for_type({:type, _, :maybe_improper_list, []}) do
+    any = &is_any/1
+
+    &is_improper_list(&1, any, any)
+  end
+
+  defp validator_for_type({:type, _, :maybe_improper_list, [type1, type2]}) do
+    head_fun = validator_for_type(type1)
+    member_fun = validator_for_type(type2)
+
+    tail_fun = is_one_of([head_fun, member_fun])
+
+    &is_improper_list(&1, head_fun, tail_fun)
+  end
+
+  defp validator_for_type({:type, _, :nonempty_improper_list, [type1, type2]}) do
+    head_fun = validator_for_type(type1)
+    member_fun = validator_for_type(type2)
+
+    tail_fun = is_one_of([head_fun, member_fun])
+
+    compose([&(&1 != []), &is_improper_list(&1, head_fun, tail_fun)])
+  end
+
+  defp validator_for_type({:type, _, :nonempty_maybe_improper_list, []}) do
+    any = &is_any/1
+
+    compose([&(&1 != []), &is_improper_list(&1, any, any)])
+  end
+
+  defp validator_for_type({:type, _, :nonempty_maybe_improper_list, [type1, type2]}) do
+    head_fun = validator_for_type(type1)
+    member_fun = validator_for_type(type2)
+
+    tail_fun = is_one_of([head_fun, member_fun])
+
+    &is_improper_list(&1, head_fun, tail_fun)
+  end
+
+  defp validator_for_type({:type, _, :map, :any}) do
+    &is_map/1
+  end
+
+  defp validator_for_type({:type, _, :map, []}) do
+    &(&1 == %{})
+  end
+
+  defp validator_for_type({:type, _, :map, field_types}) do
+    functions = field_types |> Enum.map(&validate_map_field/1)
+
+    exact = for {:exact, f} <- functions, do: f
+
+    general = for {:general, f} <- functions, do: f
+    general = compose(general)
+
+    fn
+      x when is_map(x) ->
+        map =
+          Enum.reduce(exact, x, fn current, acc ->
+            current.(acc)
+          end)
+
+        if is_map(map) do
+          general.(map)
+        else
+          false
+        end
+
+      _ ->
+        false
+    end
+  end
+
+  defp validator_for_type({type, _, literal}) when type in [:atom, :integer] do
+    &(&1 == literal)
+  end
+
+  defp validator_for_type({:type, _, :range, [{:integer, _, lower}, {:integer, _, upper}]}) do
+    compose([&is_integer/1, &(&1 in lower..upper)])
+  end
+
+  defp validator_for_type({:type, _, :binary, [{:integer, _, size}, {:integer, _, unit}]}) do
+    case {size, unit} do
+      {0, 0} ->
+        &(&1 == <<>>)
+
+      {_, _} ->
+        fn
+          x when is_bitstring(x) and rem(bit_size(x), unit) == size -> true
+          _ -> false
+        end
+    end
+  end
+
+  ## Built-in types
+  defp validator_for_type({:type, _, :arity, []}) do
+    compose([&is_integer/1, &(&1 in 0..255)])
+  end
+
+  defp validator_for_type({:type, _, :boolean, []}) do
+    &is_boolean/1
+  end
+
+  defp validator_for_type({:type, _, :byte, []}) do
+    compose([&is_integer/1, &(&1 in 0..255)])
+  end
+
+  defp validator_for_type({:type, _, :char, []}) do
+    compose([&is_integer/1, &(&1 in 0..0x10FFFF)])
+  end
+
+  defp validator_for_type({:type, _, :bitstring, []}) do
+    &is_bitstring/1
+  end
+
+  defp validator_for_type({:type, _, :binary, []}) do
+    &is_binary/1
+  end
+
+  # Note: This is the type we call charlist()
+  defp validator_for_type({:type, _, :string, []}) do
+    is_char = compose([&is_integer/1, &(&1 in 0..0x10FFFF)])
+
+    fn
+      x when is_list(x) -> Enum.all?(x, is_char)
+      _ -> false
+    end
+  end
+
+  defp validator_for_type({:type, _, :nonempty_string, []}) do
+    is_char = compose([&is_integer/1, &(&1 in 0..0x10FFFF)])
+
+    fn
+      [] -> false
+      x when is_list(x) -> Enum.all?(x, is_char)
+      _ -> false
+    end
+  end
+
+  defp validator_for_type({:remote_type, _, [{:atom, _, module}, {:atom, _, type}, args]}) do
+    type_validator_for(module, type, Enum.map(args, &validator_for_type/1))
+  end
+
+  defp validator_for_type({:type, _, :iolist, []}) do
+    &is_iolist/1
+  end
+
+  defp validator_for_type({:type, _, :iodata, []}) do
+    is_one_of([&is_binary/1, &is_iolist/1])
+  end
+
+  defp validator_for_type({:type, _, :mfa, []}) do
+    fn
+      {m, f, a} ->
+        is_atom(m) && is_atom(f) && a in 0..255
+
+      _ ->
+        false
+    end
+  end
+
+  defp validator_for_type({:type, _, x, []}) when x in [:module, :node] do
+    &is_atom/1
+  end
+
+  defp validator_for_type({:type, _, :number, []}) do
+    &is_number/1
+  end
+
+  defp validator_for_type({:type, _, :timeout, []}) do
+    is_one_of([
+      &(&1 == :infinity),
+      compose([&is_integer/1, &(&1 >= 0)])
+    ])
+  end
+
+  defp validator_for_type({:type, _, :union, types}) do
+    types
+    |> Enum.map(&validator_for_type/1)
+    |> is_one_of
+  end
+
+  defp char() do
+    integer(0..0x10FFFF)
+  end
+
+  defp non_negative_integer() do
+    map(integer(), &abs/1)
+  end
+
+  defp validate_map_field({:type, _, :map_field_exact, [{_, _, key}, value]}) do
+    member = validator_for_type(value)
+
+    has_key = fn
+      %{^key => value} = x -> member.(value) && Map.delete(x, key)
+      _ -> false
+    end
+
+    {:exact, has_key}
+  end
+
+  defp validate_map_field({:type, _, :map_field_exact, [key, value]}) do
+    key_fun = validator_for_type(key)
+    value_fun = validator_for_type(value)
+
+    member = fn
+      x when x == %{} -> false
+      x when is_map(x) -> Enum.all?(x, fn {k, v} -> key_fun.(k) && value_fun.(v) end)
+      _ -> false
+    end
+
+    {:general, member}
+  end
+
+  defp validate_map_field({:type, _, :map_field_assoc, [key, value]}) do
+    key_fun = validator_for_type(key)
+    value_fun = validator_for_type(value)
+
+    member = fn
+      x when x == %{} -> true
+      x when is_map(x) -> Enum.any?(x, fn {k, v} -> key_fun.(k) && value_fun.(v) end)
+      _ -> false
+    end
+
+    {:general, member}
   end
 
   defp rewrite_recursive_type({:type, _, _, :any} = t, _name), do: t
@@ -635,4 +1053,42 @@ defmodule StreamDataTypes do
     Code.ensure_loaded?(module) and function_exported?(module, :__protocol__, 1) and
       module.__protocol__(:module) == module
   end
+
+  defp compose(functions) do
+    fn x -> Enum.all?(functions, & &1.(x)) end
+  end
+
+  defp is_one_of(functions) do
+    fn x -> Enum.any?(functions, & &1.(x)) end
+  end
+
+  defp is_improper_list([], _head_fun, _tail_fun), do: true
+
+  defp is_improper_list([elem], _head_fun, tail_fun) do
+    tail_fun.(elem)
+  end
+
+  defp is_improper_list([head | tail], head_fun, tail_fun) do
+    head_fun.(head) &&
+      if is_list(tail) do
+        is_improper_list(tail, head_fun, tail_fun)
+      else
+        tail_fun.(tail)
+      end
+  end
+
+  defp is_improper_list(_x, _head_fun, _tail_fun), do: false
+
+  defp is_iolist([]), do: true
+  defp is_iolist(x) when is_binary(x), do: true
+  defp is_iolist([x | xs]) when x in 0..255, do: is_iolist(xs)
+  defp is_iolist([x | xs]) when is_binary(x), do: is_iolist(xs)
+
+  defp is_iolist([x | xs]) do
+    is_iolist(x) && is_iolist(xs)
+  end
+
+  defp is_iolist(_), do: false
+
+  defp is_any(_), do: true
 end

--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -705,11 +705,19 @@ defmodule StreamDataTypes do
   end
 
   defp validator_for_type({:type, _, type, _}) when type in [:none, :no_return] do
-    # TODO
+    # For function type validations - the result type should report whether it can
+    # raise and then that should get handled there
+    raise ArgumentError, """
+    Type validations for the none(bottom) type are not supported.
+    """
   end
 
-  defp validator_for_type({:type, _, type, _}) when type in [:pid, :port] do
-    # TODO
+  defp validator_for_type({:type, _, :pid, _}) do
+    &is_pid/1
+  end
+
+  defp validator_for_type({:type, _, :port, _}) do
+    &is_port/1
   end
 
   defp validator_for_type({:type, _, :integer, _}) do

--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -901,11 +901,11 @@ defmodule StreamDataTypes do
   end
 
   defp validator_for_type({:type, _, :byte, []}) do
-    compose([&is_integer/1, &(&1 in 0..255)])
+    &(&1 in 0..255)
   end
 
   defp validator_for_type({:type, _, :char, []}) do
-    compose([&is_integer/1, &(&1 in 0..0x10FFFF)])
+    &(&1 in 0..0x10FFFF)
   end
 
   defp validator_for_type({:type, _, :bitstring, []}) do

--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -1054,10 +1054,12 @@ defmodule StreamDataTypes do
       module.__protocol__(:module) == module
   end
 
+  defp compose([f]) when is_function(f, 1), do: f
   defp compose(functions) do
     fn x -> Enum.all?(functions, & &1.(x)) end
   end
 
+  defp is_one_of([f]) when is_function(f, 1), do: f
   defp is_one_of(functions) do
     fn x -> Enum.any?(functions, & &1.(x)) end
   end

--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -669,7 +669,7 @@ defmodule StreamDataTypes do
         else
           is_node =
             nodes
-            |> Enum.map(&map_user_type_to_is_node(&1, member))
+            |> Enum.map(&map_user_type_to_is_node(&1, member.(member)))
             |> Enum.map(&validator_for_type(&1))
             |> is_one_of
 
@@ -1055,11 +1055,13 @@ defmodule StreamDataTypes do
   end
 
   defp compose([f]) when is_function(f, 1), do: f
+
   defp compose(functions) do
     fn x -> Enum.all?(functions, & &1.(x)) end
   end
 
   defp is_one_of([f]) when is_function(f, 1), do: f
+
   defp is_one_of(functions) do
     fn x -> Enum.any?(functions, & &1.(x)) end
   end

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -1252,6 +1252,7 @@ defmodule StreamData.TypesTest do
       {generator, member} = generate_data(:parameterized_recursive_forest, [integers, integers])
 
       refute member.({0, [<<90, 224, 68, 77, 88, 65, 12, 6, 163>>]})
+
       check all x <- generator,
                 y <- term(),
                 !is_forest(y) do

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -1323,6 +1323,24 @@ defmodule StreamData.TypesTest do
     end
   end
 
+  test "pid type validation" do
+    member = type_validator_for(TypesList, :basic_pid)
+
+    Process.list()
+    |> Enum.each(&assert(member.(&1)))
+
+    check all y <- term(), do: refute(member.(y))
+  end
+
+  test "port type validation" do
+    member = type_validator_for(TypesList, :basic_port)
+
+    Port.list()
+    |> Enum.each(&assert(member.(&1)))
+
+    check all y <- term(), do: refute(member.(y))
+  end
+
   defp is_forest({x, forests}) when is_integer(x) and is_list(forests) do
     Enum.all?(forests, &is_forest/1)
   end

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -1251,6 +1251,7 @@ defmodule StreamData.TypesTest do
       integers = generate_data(:basic_integer)
       {generator, member} = generate_data(:parameterized_recursive_forest, [integers, integers])
 
+      refute member.({0, [<<90, 224, 68, 77, 88, 65, 12, 6, 163>>]})
       check all x <- generator,
                 y <- term(),
                 !is_forest(y) do

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -28,7 +28,7 @@ defmodule StreamData.TypesTest do
 
   test "raises when wrong number of arguments given" do
     assert_raise(ArgumentError, ~r/Could not find type with/, fn ->
-      generate_data(:basic_atom, [StreamData.integer()])
+      generate_data(:basic_atom, [{StreamData.integer(), &is_integer/1}])
     end)
   end
 
@@ -40,51 +40,83 @@ defmodule StreamData.TypesTest do
     end
 
     test "any" do
-      data = generate_data(:basic_any)
+      {generator, member} = generate_data(:basic_any)
 
-      check all term <- data, max_runs: 25 do
+      check all term <- generator, max_runs: 25 do
         assert is_term(term)
+        assert member.(term)
       end
     end
 
     test "atom" do
-      data = generate_data(:basic_atom)
+      {generator, member} = generate_data(:basic_atom)
 
-      check all x <- data, do: assert(is_atom(x))
+      check all x <- generator,
+                y <- term(),
+                !is_atom(y),
+                max_runs: 25 do
+        assert is_atom(x)
+        assert member.(x)
+        refute member.(y)
+      end
     end
 
     test "map" do
-      data = generate_data(:basic_map)
+      {generator, member} = generate_data(:basic_map)
 
       # Check that not all generated maps are empty
-      assert Enum.take(data, 5)
+      assert Enum.take(generator, 5)
              |> Enum.map(&map_size(&1))
              |> Enum.sum() > 0
 
-      check all x <- data, max_runs: 25 do
+      check all x <- generator,
+                y <- term(),
+                !is_map(y),
+                max_runs: 25 do
         assert is_map(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "struct" do
-      data = generate_data(:basic_struct)
+      {generator, member} = generate_data(:basic_struct)
 
-      check all x <- data, max_runs: 25 do
+      refute member.(%{key: :bar})
+
+      check all x <- generator,
+                y <- term(),
+                !is_map(y),
+                max_runs: 25 do
         assert %_{} = x
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "reference" do
-      data = generate_data(:basic_reference)
+      {generator, member} = generate_data(:basic_reference)
 
-      check all x <- data, do: assert(is_reference(x))
+      check all x <- generator do
+        assert is_reference(x)
+        assert member.(x)
+      end
+
+      check all x <- term(), !is_reference(x) do
+        refute member.(x)
+      end
     end
 
     test "tuple" do
-      data = generate_data(:basic_tuple)
+      {generator, member} = generate_data(:basic_tuple)
 
-      check all x <- data, max_runs: 25 do
+      check all x <- generator,
+                y <- term(),
+                !is_tuple(y),
+                max_runs: 25 do
         assert is_tuple(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
@@ -102,108 +134,176 @@ defmodule StreamData.TypesTest do
 
     # Numbers
     test "float" do
-      data = generate_data(:basic_float)
+      {generator, member} = generate_data(:basic_float)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !is_float(y),
+                max_runs: 25 do
         assert is_float(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "integer" do
-      data = generate_data(:basic_integer)
+      {generator, member} = generate_data(:basic_integer)
 
-      check all x <- data, do: assert(is_integer(x))
+      check all x <- generator,
+                y <- term(),
+                !is_integer(y) do
+        assert is_integer(x)
+        assert member.(x)
+        refute member.(y)
+      end
     end
 
     test "pos_integer" do
-      data = generate_data(:basic_pos_integer)
+      {generator, member} = generate_data(:basic_pos_integer)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_integer(y) && y > 0) do
         assert is_integer(x)
         assert x > 0
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "non_neg_integer" do
-      data = generate_data(:basic_non_neg_integer)
+      {generator, member} = generate_data(:basic_non_neg_integer)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_integer(y) && y >= 0) do
         assert is_integer(x)
         assert x >= 0
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "neg_integer" do
-      data = generate_data(:basic_neg_integer)
+      {generator, member} = generate_data(:basic_neg_integer)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_integer(y) && y < 0) do
         assert is_integer(x)
         assert x < 0
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "lists" do
-      data = generate_data(:basic_list_type)
+      {generator, member} = generate_data(:basic_list_type)
 
-      check all list <- data, max_runs: 25 do
+      refute member.([:a])
+
+      check all list <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert is_list(list)
         assert Enum.all?(list, fn x -> is_integer(x) end)
+        assert member.(list)
+        refute member.(y)
       end
     end
 
     test "basic nonempty list" do
-      data = generate_data(:basic_nonempty_list_type)
+      {generator, member} = generate_data(:basic_nonempty_list_type)
 
-      check all list <- data, max_runs: 25 do
+      refute member.([])
+      refute member.([:a])
+
+      check all list <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert is_list(list)
         assert length(list) > 0
         assert Enum.all?(list, fn x -> is_integer(x) end)
+        assert member.(list)
+        refute member.(y)
       end
     end
 
     test "maybe_improper_list" do
-      data = generate_data(:basic_maybe_improper_list_type)
+      {generator, member} = generate_data(:basic_maybe_improper_list_type)
 
-      check all list <- data do
+      check all list <- generator,
+                y <- term(),
+                !is_list(y) do
         each_improper_list(list, &assert(is_integer(&1)), &assert(is_float(&1) or is_integer(&1)))
+        assert member.(list)
+        refute member.(y)
+        refute member.([1.0 | 1.0])
       end
     end
 
     test "nonempty_improper_list" do
-      data = generate_data(:basic_nonempty_improper_list_type)
+      {generator, member} = generate_data(:basic_nonempty_improper_list_type)
 
-      check all list <- data do
+      check all list <- generator,
+                y <- term(),
+                !is_list(y) do
         assert list != []
         each_improper_list(list, &assert(is_integer(&1)), &assert(is_float(&1)))
+        assert member.(list)
+        refute member.(y)
+        refute member.([1.0 | 1.0])
       end
     end
 
     test "nonempty_maybe_improper_list" do
-      data = generate_data(:basic_nonempty_maybe_improper_list_type)
+      {generator, member} = generate_data(:basic_nonempty_maybe_improper_list_type)
 
-      check all list <- data do
+      check all list <- generator,
+                y <- term(),
+                !is_list(y) do
         assert list != []
         each_improper_list(list, &assert(is_integer(&1)), &assert(is_float(&1) or is_integer(&1)))
+        assert member.(list)
+        refute member.(y)
+        refute member.([1.0 | 1.0])
       end
     end
 
     test "nested lists" do
-      data = generate_data(:nested_list_type)
+      {generator, member} = generate_data(:nested_list_type)
 
-      check all list <- data, max_runs: 25 do
+      refute member.([1])
+      refute member.([[1.0]])
+
+      check all list <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert is_list(list)
 
         Enum.each(list, fn x ->
           assert is_list(x)
           assert Enum.all?(x, &is_integer(&1))
         end)
+
+        assert member.(list)
+        refute member.(y)
       end
     end
 
     test "nested nonempty list" do
-      data = generate_data(:nested_nonempty_list_type)
+      {generator, member} = generate_data(:nested_nonempty_list_type)
 
-      check all list <- data, max_runs: 25 do
+      refute member.([1])
+      refute member.([[1.0]])
+
+      check all list <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert is_list(list)
         assert length(list) > 0
 
@@ -211,245 +311,389 @@ defmodule StreamData.TypesTest do
           assert is_list(x)
           assert Enum.all?(x, &is_integer(&1))
         end)
+
+        assert member.(list)
+        refute member.(y)
       end
     end
   end
 
   describe "builtin" do
     test "list" do
-      data = generate_data(:builtin_list)
+      {generator, member} = generate_data(:builtin_list)
 
-      check all x <- data, max_runs: 25 do
+      check all x <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert is_list(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "nonempty_list" do
-      data = generate_data(:builtin_nonempty_list)
+      {generator, member} = generate_data(:builtin_nonempty_list)
 
-      check all x <- data, max_runs: 25 do
+      check all x <- generator,
+                y <- term(),
+                !(is_list(y) && y != []),
+                max_runs: 25 do
         assert is_list(x)
-        assert x != []
+        assert length(x) > 0
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "maybe_improper_list" do
-      data = generate_data(:builtin_maybe_improper_list)
+      {generator, member} = generate_data(:builtin_maybe_improper_list)
 
-      check all list <- data, max_runs: 25 do
+      check all list <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         each_improper_list(list, &assert(is_term(&1)), &assert(is_term(&1)))
+        assert member.(list)
+        refute member.(y)
       end
     end
 
     test "nonempty_maybe_improper_list" do
-      data = generate_data(:builtin_nonempty_maybe_improper_list)
+      {generator, member} = generate_data(:builtin_nonempty_maybe_improper_list)
 
-      check all list <- data, max_runs: 25 do
+      check all list <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert list != []
         each_improper_list(list, &assert(is_term(&1)), &assert(is_term(&1)))
+        assert member.(list)
+        refute member.(y)
       end
     end
   end
 
   describe "literals" do
     test "list type" do
-      data = generate_data(:literal_list_type)
+      {generator, member} = generate_data(:literal_list_type)
 
-      check all x <- data do
+      refute member.([1, -1.0])
+
+      check all x <- generator,
+                y <- term(),
+                !is_list(y) do
         assert is_list(x)
         assert Enum.all?(x, &is_integer(&1))
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "empty list" do
-      data = generate_data(:literal_empty_list)
+      {generator, member} = generate_data(:literal_empty_list)
 
-      check all x <- data do
+      assert member.([])
+
+      check all x <- generator,
+                y <- term(),
+                !(y == []) do
         assert x == []
+        refute member.(y)
       end
     end
 
     test "nonempty list" do
-      data = generate_data(:literal_list_nonempty)
+      {generator, member} = generate_data(:literal_list_nonempty)
 
-      check all x <- data, max_runs: 25 do
+      check all x <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert is_list(x)
         assert x != []
+        assert member.(x)
+        refute member.([])
+        refute member.(y)
       end
     end
 
     test "nonempty list with type" do
-      data = generate_data(:literal_nonempty_list_type)
+      {generator, member} = generate_data(:literal_nonempty_list_type)
 
-      check all x <- data, max_runs: 25 do
+      check all x <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert is_list(x)
         assert x != []
         assert Enum.all?(x, &is_float(&1))
+        assert member.(x)
+        refute member.([1])
+        refute member.(y)
       end
     end
 
     test "empty map" do
-      data = generate_data(:literal_empty_map)
+      {generator, member} = generate_data(:literal_empty_map)
 
-      check all x <- data do
+      assert member.(%{})
+
+      check all x <- generator,
+                y <- term(),
+                !(y == %{}) do
         assert x == %{}
+        refute member.(y)
       end
     end
 
     test "map with fixed key" do
-      data = generate_data(:literal_map_with_key)
+      {generator, member} = generate_data(:literal_map_with_key)
 
-      check all x <- data, max_runs: 25 do
-        assert is_map(x)
-        %{key: int} = x
+      refute member.(%{key: :foo})
+
+      check all x = %{key: int} <- generator,
+                y <- term(),
+                !is_map(y),
+                max_runs: 25 do
         assert is_integer(int)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "map with optional key" do
-      data = generate_data(:literal_map_with_optional_key)
+      {generator, member} = generate_data(:literal_map_with_optional_key)
 
-      check all x <- data, max_runs: 25 do
+      refute member.(%{1.0 => :foo})
+      refute member.(%{:foo => -1})
+
+      check all x <- generator,
+                y <- term(),
+                !is_map(y),
+                max_runs: 25 do
         assert is_map(x)
 
-        assert Map.keys(x) |> Enum.all?(fn k -> is_float(k) end)
-        assert Map.values(x) |> Enum.all?(fn v -> is_integer(v) end)
+        assert Enum.all?(x, fn {k, v} ->
+                 is_float(k) && is_integer(v)
+               end)
+
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "map with required keys" do
-      data = generate_data(:literal_map_with_required_key)
+      {generator, member} = generate_data(:literal_map_with_required_key)
 
-      check all x <- data, max_runs: 25 do
+      refute member.(%{})
+      refute member.(%{1.0 => :foo})
+      refute member.(%{:foo => -1})
+
+      check all x <- generator, max_runs: 25 do
         assert is_map(x)
         assert x != %{}
 
-        assert Map.keys(x) |> Enum.all?(fn k -> is_float(k) end)
-        assert Map.values(x) |> Enum.all?(fn v -> is_integer(v) end)
+        assert Enum.all?(x, fn {k, v} ->
+                 is_float(k) && is_integer(v)
+               end)
+
+        assert member.(x)
       end
     end
 
     test "map with required and optional key" do
-      data = generate_data(:literal_map_with_required_and_optional_key)
+      {generator, member} = generate_data(:literal_map_with_required_and_optional_key)
 
-      check all x <- data, max_runs: 25 do
+      refute member.(%{1.0 => 1})
+
+      check all x <- generator,
+                y <- term(),
+                !is_map(y),
+                max_runs: 25 do
         assert is_map(x)
 
         %{key: int} = x
         map = Map.delete(x, :key)
         assert is_integer(int)
 
-        assert Map.keys(map) |> Enum.all?(fn k -> is_float(k) end)
-        assert Map.values(map) |> Enum.all?(fn v -> is_integer(v) end)
+        assert Enum.all?(map, fn {k, v} ->
+                 is_float(k) && is_integer(v)
+               end)
+
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "struct with all fields any type" do
-      data = generate_data(:literal_struct_all_fields_any_type)
+      {generator, member} = generate_data(:literal_struct_all_fields_any_type)
 
-      check all x <- data, max_runs: 25 do
+      refute member.(%{key: :bar})
+
+      check all x <- generator,
+                y <- term(),
+                !is_map(y),
+                max_runs: 25 do
         assert %StreamDataTest.TypesList.SomeStruct{key: value} = x
         assert is_term(value)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "struct with all fields key type" do
-      data = generate_data(:literal_struct_all_fields_key_type)
+      {generator, member} = generate_data(:literal_struct_all_fields_key_type)
 
-      check all x <- data, max_runs: 25 do
+      check all x <- generator,
+                y <- term(),
+                !is_map(y),
+                max_runs: 25 do
         assert %StreamDataTest.TypesList.SomeStruct{key: value} = x
         assert is_integer(value)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "empty tuple" do
-      data = generate_data(:literal_empty_tuple)
+      {generator, member} = generate_data(:literal_empty_tuple)
 
-      check all x <- data, do: assert(x == {})
+      assert member.({})
+
+      check all x <- generator,
+                y <- term(),
+                !(y == {}) do
+        assert x == {}
+        refute member.(y)
+      end
     end
 
     test "2 element tuple with fixed and random type" do
-      data = generate_data(:literal_2_element_tuple)
+      {generator, member} = generate_data(:literal_2_element_tuple)
 
-      check all {int, float} <- data do
+      check all x = {int, float} <- generator,
+                y <- term(),
+                !(is_tuple(y) && tuple_size(y) == 2) do
         assert is_integer(int)
         assert is_float(float)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "atom" do
-      data = generate_data(:literal_atom)
+      {generator, member} = generate_data(:literal_atom)
 
-      check all x <- data do
+      assert member.(:atom)
+
+      check all x <- generator,
+                y <- term(),
+                !(y == :atom) do
         assert x == :atom
+        refute member.(y)
       end
     end
 
     test "special atom" do
-      data = generate_data(:literal_special_atom)
+      {generator, member} = generate_data(:literal_special_atom)
 
-      check all x <- data do
+      assert member.(false)
+
+      check all x <- generator,
+                y <- term(),
+                !(y == false) do
         assert x == false
+        refute member.(y)
       end
     end
 
     test "integer" do
-      data = generate_data(:literal_integer)
+      {generator, member} = generate_data(:literal_integer)
 
-      check all x <- data do
+      assert member.(1)
+
+      check all x <- generator,
+                y <- term(),
+                !(y == 1) do
         assert x == 1
+        refute member.(y)
       end
     end
 
     test "range" do
-      data = generate_data(:literal_integers)
+      {generator, member} = generate_data(:literal_integers)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_integer(y) && y in 0..10) do
         assert is_integer(x)
         assert x in 0..10
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "bitstrings" do
-      data = generate_data(:literal_empty_bitstring)
+      {generator, member} = generate_data(:literal_empty_bitstring)
 
-      check all x <- data do
+      assert member.("")
+
+      check all x <- generator,
+                y <- term(),
+                y != "" do
         assert x == ""
+        refute member.(y)
       end
     end
 
     test "bitstrings with size 0" do
-      data = generate_data(:literal_size_0)
+      {generator, member} = generate_data(:literal_size_0)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(y == "") do
         assert "" == x
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "bitstrings with unit 1" do
-      data = generate_data(:literal_unit_1)
+      {generator, member} = generate_data(:literal_unit_1)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !is_bitstring(y) do
         assert is_bitstring(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "bitstrings with size 1 and unit 8" do
-      data = generate_data(:literal_size_1_unit_8)
+      {generator, member} = generate_data(:literal_size_1_unit_8)
 
-      check all x <- data do
+      refute member.(<<209, 48, 176, 36>>)
+
+      check all x <- generator,
+                y <- term(),
+                !is_bitstring(y) do
         size = bit_size(x)
         assert rem(size, 8) == 1
+        assert member.(x)
+        refute member.(y)
       end
     end
   end
 
   describe "built-in" do
     test "term" do
-      data = generate_data(:builtin_term)
+      {generator, member} = generate_data(:builtin_term)
 
-      check all term <- data, max_runs: 25 do
+      check all term <- generator, max_runs: 25 do
         assert is_term(term)
+        assert member.(term)
       end
     end
 
@@ -460,186 +704,294 @@ defmodule StreamData.TypesTest do
     end
 
     test "arity" do
-      data = generate_data(:builtin_arity)
+      {generator, member} = generate_data(:builtin_arity)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_integer(y) && y in 0..255) do
         assert is_integer(x)
         assert x in 0..255
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "binary" do
-      data = generate_data(:builtin_binary)
+      {generator, member} = generate_data(:builtin_binary)
 
-      check all x <- data, do: assert(is_binary(x))
+      check all x <- generator,
+                y <- term(),
+                !is_binary(y) do
+        assert is_binary(x)
+        assert member.(x)
+        refute member.(y)
+      end
     end
 
     test "bitstring" do
-      data = generate_data(:builtin_bitstring)
+      {generator, member} = generate_data(:builtin_bitstring)
 
-      check all x <- data, do: assert(is_bitstring(x))
+      check all x <- generator,
+                y <- term(),
+                !is_bitstring(y) do
+        assert is_bitstring(x)
+        assert member.(x)
+        refute member.(y)
+      end
     end
 
     test "boolean" do
-      data = generate_data(:builtin_boolean)
+      {generator, member} = generate_data(:builtin_boolean)
 
-      check all x <- data, do: assert(is_boolean(x))
+      check all x <- generator,
+                y <- term(),
+                !is_boolean(y) do
+        assert is_boolean(x)
+        assert member.(x)
+        refute member.(y)
+      end
     end
 
     test "byte" do
-      data = generate_data(:builtin_byte)
+      {generator, member} = generate_data(:builtin_byte)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_integer(y) && y in 0..255) do
         assert is_integer(x)
         assert x in 0..255
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "char" do
-      data = generate_data(:builtin_char)
+      {generator, member} = generate_data(:builtin_char)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_integer(y) && y in 0..0x10FFFF) do
         assert is_integer(x)
         assert x in 0..0x10FFFF
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "charlist" do
-      data = generate_data(:builtin_charlist)
+      {generator, member} = generate_data(:builtin_charlist)
 
-      check all x <- data do
+      refute member.([-1, 5])
+
+      check all x <- generator,
+                y <- term(),
+                !is_list(y) do
         assert is_list(x)
-
         assert Enum.all?(x, &(&1 in 0..0x10FFFF))
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "nonempty charlist" do
-      data = generate_data(:builtin_nonempty_charlist)
+      {generator, member} = generate_data(:builtin_nonempty_charlist)
 
-      check all x <- data do
+      refute member.([-1, 5])
+
+      check all x <- generator,
+                y <- term(),
+                !is_list(y) do
         assert is_list(x)
         assert x != []
 
         assert Enum.all?(x, &(&1 in 0..0x10FFFF))
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "iodata" do
-      data = generate_data(:builtin_iodata)
+      {generator, member} = generate_data(:builtin_iodata)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_binary(y) or is_iolist(y)) do
         assert is_binary(x) or is_iolist(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "iolist" do
-      data = generate_data(:builtin_iolist)
+      {generator, member} = generate_data(:builtin_iolist)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !is_iolist(y) do
         assert is_iolist(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "mfa" do
-      data = generate_data(:builtin_mfa)
+      {generator, member} = generate_data(:builtin_mfa)
 
-      check all {module, function, arity} <- data, max_runs: 25 do
+      refute member.({:foo, :bar, :baz})
+
+      check all x = {module, function, arity} <- generator,
+                y <- term(),
+                !(is_tuple(y) && tuple_size(y) == 3),
+                max_runs: 25 do
         assert is_atom(module)
         assert is_atom(function)
-        assert is_integer(arity)
         assert arity in 0..255
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "module" do
-      data = generate_data(:builtin_module)
+      {generator, member} = generate_data(:builtin_module)
 
-      check all x <- data, do: assert(is_atom(x))
+      check all x <- generator,
+                y <- term(),
+                !is_atom(y) do
+        assert is_atom(x)
+        assert member.(x)
+        refute member.(y)
+      end
     end
 
     test "node" do
-      data = generate_data(:builtin_node)
+      {generator, member} = generate_data(:builtin_node)
 
-      check all x <- data, do: assert(is_atom(x))
+      check all x <- generator,
+                y <- term(),
+                !is_atom(y) do
+        assert is_atom(x)
+        assert member.(x)
+        refute member.(y)
+      end
     end
 
     test "number" do
-      data = generate_data(:builtin_number)
+      {generator, member} = generate_data(:builtin_number)
 
-      check all x <- data, do: assert(is_number(x))
+      check all x <- generator,
+                y <- term(),
+                !is_number(y) do
+        assert is_number(x)
+        assert member.(x)
+        refute member.(y)
+      end
     end
 
     test "timeout" do
-      data = generate_data(:builtin_timeout)
+      {generator, member} = generate_data(:builtin_timeout)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(y == :infinity or is_integer(y)) do
         assert x == :infinity or is_integer(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
   end
 
   describe "remote types" do
     test "without parameters" do
-      data = generate_data(:remote_string)
+      {generator, member} = generate_data(:remote_string)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !is_bitstring(y) do
         assert is_bitstring(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "remote types with a passed in compile time parameter" do
-      data = generate_data(:remote_keyword_list)
+      {generator, member} = generate_data(:remote_keyword_list)
 
-      check all keyword_list <- data do
+      refute member.([1, 2, 3])
+
+      check all keyword_list <- generator,
+                y <- term(),
+                !is_list(y) do
         assert is_list(keyword_list)
 
         Enum.each(keyword_list, fn {atom, integer} ->
           assert is_atom(atom)
           assert is_integer(integer)
         end)
+
+        assert member.(keyword_list)
+        refute member.(y)
       end
     end
   end
 
   describe "union types" do
     test "with two types" do
-      data = generate_data(:union_with_two)
+      {generator, member} = generate_data(:union_with_two)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_atom(y) or is_integer(y)) do
         assert is_atom(x) or is_integer(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "with three types" do
-      data = generate_data(:union_with_three)
+      {generator, member} = generate_data(:union_with_three)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_atom(y) or is_integer(y) or y == true) do
         assert is_atom(x) or is_integer(x) or x == true
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "all basic types union" do
-      data = generate_data(:union_basic_types)
+      {generator, member} = generate_data(:union_basic_types)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_atom(y) or is_reference(y) or is_integer(y) or is_float(y)) do
         assert is_atom(x) or is_reference(x) or is_integer(x) or is_float(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "with user defined type" do
-      data = generate_data(:union_with_user_defined_atom)
+      {generator, member} = generate_data(:union_with_user_defined_atom)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_atom(y) or is_integer(y)) do
         assert is_atom(x) or is_integer(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "with remote types" do
-      data = generate_data(:union_with_remote_types)
+      {generator, member} = generate_data(:union_with_remote_types)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !(is_integer(y) or is_bitstring(y)) do
         assert is_integer(x) or is_bitstring(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
   end
@@ -647,24 +999,38 @@ defmodule StreamData.TypesTest do
   # Test that user defined types are inlined correctly
   describe "user defined types" do
     test "lists" do
-      data = generate_data(:user_defined_list)
+      {generator, member} = generate_data(:user_defined_list)
 
-      check all list <- data do
+      refute member.([1])
+
+      check all list <- generator,
+                y <- term(),
+                !is_list(y),
+                max_runs: 25 do
         assert is_list(list)
         assert Enum.all?(list, &is_atom(&1))
+        assert member.(list)
+        refute member.(y)
       end
     end
 
     test "map" do
-      data = generate_data(:user_defined_map)
+      {generator, member} = generate_data(:user_defined_map)
 
-      check all map <- data do
+      refute member.(%{atom: 1})
+
+      check all map <- generator,
+                y <- term(),
+                !is_map(y),
+                max_runs: 25 do
         assert %{atom: atom} = map
         assert is_atom(atom)
+        assert member.(map)
+        refute member.(y)
       end
 
       # Take 100 maps and check at least one has gotten a string: string key
-      assert data
+      assert generator
              |> Enum.take(100)
              |> Enum.any?(fn %{string: string} ->
                is_bitstring(string)
@@ -672,53 +1038,82 @@ defmodule StreamData.TypesTest do
     end
 
     test "tuples" do
-      data = generate_data(:user_defined_tuple)
+      {generator, member} = generate_data(:user_defined_tuple)
 
-      check all {:atom, atom} <- data do
+      check all x = {:atom, atom} <- generator,
+                y <- term(),
+                !(is_tuple(y) && tuple_size(y) == 2) do
         assert is_atom(atom)
+        assert member.(x)
+        refute member.(y)
       end
     end
   end
 
   describe "recursive type" do
     test "list with tuples" do
-      data = generate_data(:recursive_tuple)
+      {generator, member} = generate_data(:recursive_tuple)
 
-      check all x <- data do
+      refute member.({0, false})
+
+      check all x <- generator,
+                y <- term(),
+                !is_recursive_tuple(y) do
         assert is_recursive_tuple(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "expressions" do
-      data = generate_data(:recursive_expression)
+      {generator, member} = generate_data(:recursive_expression)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !is_expression(y) do
         assert is_expression(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "integers with map container" do
-      data = generate_data(:recursive_integers)
+      {generator, member} = generate_data(:recursive_integers)
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !is_recursive_integer(y) do
         assert is_recursive_integer(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "forests" do
-      data = generate_data(:recursive_forest)
+      {generator, member} = generate_data(:recursive_forest)
 
-      check all x <- data do
+      refute member.({0, [-1.0]})
+
+      check all x <- generator,
+                y <- term(),
+                !is_forest(y) do
         assert is_forest(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "forest with maps" do
-      data = generate_data(:recursive_map_forest)
+      {generator, member} = generate_data(:recursive_map_forest)
 
       # TODO: Figure out why maps generate so much duplicates
-      check all x <- data, max_runs: 1 do
+      check all x <- generator,
+                y <- term(),
+                !is_map_forest(y),
+                max_runs: 1 do
         assert is_map_forest(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
   end
@@ -748,116 +1143,166 @@ defmodule StreamData.TypesTest do
   end
 
   describe "parameterized types" do
-    test "accepts only generators as arguments" do
+    test "accepts only generators with a member function as arguments" do
       assert_raise(ArgumentError, ~r/Expected a StreamData generator/, fn ->
         generate_data(:parameterized_simple, [:integer])
       end)
     end
 
     test "you can pass in basic generators as arguments" do
-      data = generate_data(:parameterized_simple, [generate_data(:basic_atom)])
+      {generator, member} = generate_data(:parameterized_simple, [generate_data(:basic_atom)])
 
-      check all atom <- data do
+      check all atom <- generator,
+                y <- term(),
+                !is_atom(y) do
         assert is_atom(atom)
+        assert member.(atom)
+        refute member.(y)
       end
     end
 
     test "list arguments are passed in" do
-      data = generate_data(:parameterized_list, [generate_data(:basic_integer)])
+      {generator, member} = generate_data(:parameterized_list, [generate_data(:basic_integer)])
 
-      check all list <- data do
+      refute member.([:foo])
+
+      check all list <- generator,
+                y <- term(),
+                !is_list(y) do
         assert is_list(list)
         assert Enum.all?(list, &is_integer/1)
+        assert member.(list)
+        refute member.(y)
       end
     end
 
     test "tuple container need correct size of arguments" do
-      data =
+      {generator, member} =
         generate_data(:parameterized_tuple, [
           generate_data(:basic_integer),
           generate_data(:basic_atom),
-          StreamData.constant(:key)
+          {StreamData.constant(:key), &(&1 == :key)}
         ])
 
-      check all {int, atom, :key} <- data do
+      check all x = {int, atom, :key} <- generator,
+                y <- term(),
+                !(is_tuple(y) && tuple_size(y) == 3) do
         assert is_integer(int)
         assert is_atom(atom)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "map container can be parameterized" do
-      data =
+      {generator, member} =
         generate_data(:parameterized_map, [
           generate_data(:basic_list_type)
         ])
 
-      check all %{key: list} <- data do
+      check all x = %{key: list} <- generator,
+                y <- term(),
+                !is_map(y) do
         assert is_list(list)
         assert Enum.all?(list, &is_integer/1)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "nested containers are parameterized" do
-      data =
+      {generator, member} =
         generate_data(:parameterized_dict, [
           generate_data(:basic_atom),
           generate_data(:basic_integer)
         ])
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !Keyword.keyword?(y) do
         assert is_list(x)
 
         Enum.each(x, fn {atom, int} ->
           assert is_atom(atom)
           assert is_integer(int)
         end)
+
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "parameterized recursive types" do
       integers = generate_data(:basic_integer)
-      data = generate_data(:parameterized_recursive_tuple, [integers, integers])
+      {generator, member} = generate_data(:parameterized_recursive_tuple, [integers, integers])
 
-      check all x <- data do
+      refute member.({0, 1.0})
+
+      check all x <- generator,
+                y <- term(),
+                !is_recursive_tuple(y) do
         assert is_recursive_tuple(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "parameterized recursive types with map or list containers" do
       integers = generate_data(:basic_integer)
-      data = generate_data(:parameterized_recursive_forest, [integers, integers])
+      {generator, member} = generate_data(:parameterized_recursive_forest, [integers, integers])
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !is_forest(y) do
         assert is_forest(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "using remote types as arguments" do
-      data = generate_data(:parameterized_simple, [from_type(String, :t)])
+      {generator, member} =
+        generate_data(:parameterized_simple, [from_type_with_validator(String, :t)])
 
-      check all x <- data do
+      check all x <- generator,
+                y <- term(),
+                !is_binary(y) do
         assert is_binary(x)
+        assert member.(x)
+        refute member.(y)
       end
     end
 
     test "using parameterized remote types" do
-      data = generate_data(:parameterized_keyword, [generate_data(:basic_float)])
+      {generator, member} = generate_data(:parameterized_keyword, [generate_data(:basic_float)])
 
-      check all list <- data do
+      refute member.([1])
+
+      check all list <- generator,
+                y <- term(),
+                !is_list(y) do
         assert is_list(list)
 
         Enum.each(list, fn {atom, float} ->
           assert is_atom(atom)
           assert is_float(float)
         end)
+
+        assert member.(list)
+        refute member.(y)
       end
     end
 
     test "using parameterized remote types with remote type arguments" do
-      data =
-        generate_data(:parameterized_keyword, [from_type(Keyword, :t, [StreamData.integer()])])
+      {generator, member} =
+        generate_data(:parameterized_keyword, [
+          from_type_with_validator(Keyword, :t, [{StreamData.integer(), &is_integer/1}])
+        ])
 
-      check all x <- data, max_runs: 25 do
+      check all x <- generator,
+                y <- term(),
+                !Keyword.keyword?(y),
+                max_runs: 25 do
         assert is_list(x)
 
         Enum.each(x, fn {atom, keyword_list} ->
@@ -869,6 +1314,9 @@ defmodule StreamData.TypesTest do
             assert is_integer(integer)
           end)
         end)
+
+        assert member.(x)
+        refute member.(y)
       end
     end
   end
@@ -877,14 +1325,18 @@ defmodule StreamData.TypesTest do
     Enum.all?(forests, &is_forest/1)
   end
 
+  defp is_forest(_), do: false
+
   defp is_map_forest(%{int: x, forests: forests}) when is_integer(x) and is_list(forests) do
     Enum.all?(forests, &is_map_forest/1)
   end
 
   defp is_map_forest(%{int: x}) when is_integer(x), do: true
+  defp is_map_forest(_), do: false
 
   defp is_recursive_integer(:zero), do: true
   defp is_recursive_integer(%{succ: x}), do: is_recursive_integer(x)
+  defp is_recursive_integer(_), do: false
 
   defp is_expression(x) when is_integer(x), do: true
 
@@ -896,6 +1348,7 @@ defmodule StreamData.TypesTest do
 
   defp is_recursive_tuple(nil), do: true
   defp is_recursive_tuple({a, b}) when is_integer(a), do: is_recursive_tuple(b)
+  defp is_recursive_tuple(_), do: false
 
   defp each_improper_list([], _head_fun, _tail_fun), do: :ok
 
@@ -930,6 +1383,6 @@ defmodule StreamData.TypesTest do
   defp is_iolist(_), do: false
 
   defp generate_data(name, args \\ []) do
-    from_type(TypesList, name, args)
+    from_type_with_validator(TypesList, name, args)
   end
 end


### PR DESCRIPTION
This PR aims to add creation of type validating functions with 1 argument - any term, which returns whether a certain type belongs to a type family.
For simple types - when you have an integer type -> return `&is_integer/1`.  Users can expect the closest representation to their type from the `&Kernel.is_*/1` family.

To make recursive type validations work - reuse code from the
generators:
  - detecting whether the type recurses
  - splitting nodes and leaves

When we get the nodes and leaves - getting a type validator for the
leaves is kinda easy - map the type validator function over the leaves type ASTs and
the leaves functions should just check that one of those functions
returns true.

Getting the node part is harder since the node part is actually the
function the user needs. So when generating the node function it has
to look something like:

```
is_node = fn term ->
  if is_leaf.(term) do
    true
  else
    # map is_node to the inner parts of the type AST
    # to get one level deeper in the type
    node.(term)
  end
end
```

But since elixir does not support self referencing anonymous functions
there is a little dance around that - to illustrate it in a clean way
we can just look at an anonymous recursive factorial:

```
factorial = fn (me) ->
  fn
    0 -> 1
    n -> n * me.(me).(n - 1)
  end
end
```

The same way I access the is_node part while being defined.