### PR TITLE
Add function validation function.

### DIFF
--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -223,7 +223,20 @@ defmodule StreamDataTypes do
     check_all(generator, [initial_seed: :os.timestamp()], fun)
   end
 
-  defp build_check_all_function(function, member, has_no_return) do
+  defp build_check_all_function(function, _member, true) do
+    fn args ->
+      try do
+        apply(function, args)
+
+        {:ok, :no_return}
+      rescue
+        _ ->
+          {:ok, :no_return}
+      end
+    end
+  end
+
+  defp build_check_all_function(function, member, _) do
     fn args ->
       try do
         return_type = apply(function, args)
@@ -235,11 +248,7 @@ defmodule StreamDataTypes do
         end
       rescue
         _ ->
-          if has_no_return do
-            {:ok, nil}
-          else
-            {:error, :unspecified_no_return}
-          end
+          {:ok, nil}
       end
     end
   end

--- a/lib/stream_data_types.ex
+++ b/lib/stream_data_types.ex
@@ -228,7 +228,7 @@ defmodule StreamDataTypes do
       try do
         apply(function, args)
 
-        {:ok, :no_return}
+        {:error, :no_return_specified}
       rescue
         _ ->
           {:ok, :no_return}

--- a/test/stream_data/functions.ex
+++ b/test/stream_data/functions.ex
@@ -1,4 +1,7 @@
 defmodule StreamDataTest.Functions do
+  @type t(a) :: a
+  @type dict(a) :: {atom(), a}
+
   @spec test_no_return(any) :: any | no_return
   def test_no_return(x) when is_integer(x) do
     raise ArgumentError
@@ -31,4 +34,13 @@ defmodule StreamDataTest.Functions do
   def test_overloaded_with_var(x, y) when is_integer(x) and is_integer(y), do: x + y
   @spec test_overloaded_with_var(x :: atom, y :: atom) :: atom
   def test_overloaded_with_var(x, y) when is_atom(x) and is_atom(y), do: x
+
+  @spec test_type_variable(dict(integer)) :: dict(float)
+  def test_type_variable({a, int}), do: {a, int / 1}
+
+  @spec test_remote_type(Keyword.t(integer)) :: Keyword.t(integer)
+  def test_remote_type(x), do: x
+
+  @spec test_nested_user_types(t(t(integer))) :: t(t(t(integer)))
+  def test_nested_user_types(x), do: x
 end

--- a/test/stream_data/functions.ex
+++ b/test/stream_data/functions.ex
@@ -26,4 +26,9 @@ defmodule StreamDataTest.Functions do
 
   @spec test_wrong_return(integer) :: integer
   def test_wrong_return(_), do: :foo
+
+  @spec test_overloaded_with_var(x :: integer, y :: integer) :: integer
+  def test_overloaded_with_var(x, y) when is_integer(x) and is_integer(y), do: x + y
+  @spec test_overloaded_with_var(x :: atom, y :: atom) :: atom
+  def test_overloaded_with_var(x, y) when is_atom(x) and is_atom(y), do: x
 end

--- a/test/stream_data/functions.ex
+++ b/test/stream_data/functions.ex
@@ -2,12 +2,13 @@ defmodule StreamDataTest.Functions do
   @type t(a) :: a
   @type dict(a) :: {atom(), a}
 
-  @spec test_no_return(any) :: any | no_return
-  def test_no_return(x) when is_integer(x) do
+  @spec test_no_return(any) :: no_return
+  def test_no_return(_) do
     raise ArgumentError
   end
 
-  def test_no_return(x), do: x
+  @spec test_wrong_no_return(any) :: no_return
+  def test_wrong_no_return(x), do: x
 
   @spec test_names(year :: integer, month :: integer, day :: integer) :: integer
   def test_names(year, month, day), do: year + month + day

--- a/test/stream_data/functions.ex
+++ b/test/stream_data/functions.ex
@@ -1,0 +1,29 @@
+defmodule StreamDataTest.Functions do
+  @spec test_no_return(any) :: any | no_return
+  def test_no_return(x) when is_integer(x) do
+    raise ArgumentError
+  end
+
+  def test_no_return(x), do: x
+
+  @spec test_names(year :: integer, month :: integer, day :: integer) :: integer
+  def test_names(year, month, day), do: year + month + day
+
+  @spec test_guards(arg) :: [arg] when arg: atom
+  def test_guards(x), do: [x]
+
+  @spec test_multiple_guards(x, y, z) :: {x, y, z} when x: integer, y: atom, z: float
+  def test_multiple_guards(x, y, z), do: {x, y, z}
+
+  @spec test_overloaded_spec(integer) :: atom
+  def test_overloaded_spec(x) when is_integer(x), do: :foo
+  @spec test_overloaded_spec(atom) :: integer
+  def test_overloaded_spec(x) when is_atom(x), do: 1
+
+  @spec test_missing_no_return(integer) :: integer
+  def test_missing_no_return(x) when x > 0, do: raise "oops"
+  def test_missing_no_return(x), do: x
+
+  @spec test_wrong_return(integer) :: integer
+  def test_wrong_return(_), do: :foo
+end

--- a/test/stream_data/functions.ex
+++ b/test/stream_data/functions.ex
@@ -23,9 +23,9 @@ defmodule StreamDataTest.Functions do
   @spec test_overloaded_spec(atom) :: integer
   def test_overloaded_spec(x) when is_atom(x), do: 1
 
-  @spec test_missing_no_return(integer) :: integer
-  def test_missing_no_return(x) when x > 0, do: raise("oops")
-  def test_missing_no_return(x), do: x
+  @spec test_sometime_raise(integer) :: integer
+  def test_sometime_raise(x) when x > 0, do: raise("oops")
+  def test_sometime_raise(x), do: x
 
   @spec test_wrong_return(integer) :: integer
   def test_wrong_return(_), do: :foo

--- a/test/stream_data/functions.ex
+++ b/test/stream_data/functions.ex
@@ -21,7 +21,7 @@ defmodule StreamDataTest.Functions do
   def test_overloaded_spec(x) when is_atom(x), do: 1
 
   @spec test_missing_no_return(integer) :: integer
-  def test_missing_no_return(x) when x > 0, do: raise "oops"
+  def test_missing_no_return(x) when x > 0, do: raise("oops")
   def test_missing_no_return(x), do: x
 
   @spec test_wrong_return(integer) :: integer

--- a/test/stream_data/types_list.ex
+++ b/test/stream_data/types_list.ex
@@ -143,4 +143,7 @@ defmodule StreamDataTest.TypesList do
   @type parameterized_recursive_tuple(a) :: nil | {a, parameterized_recursive_tuple(a)}
   @type parameterized_recursive_forest(a) :: {a, [parameterized_recursive_forest(a)]}
   @type parameterized_keyword(a) :: Keyword.t(a)
+
+  ## Type with names
+  @type named_colour :: {red :: integer, green :: integer, blue :: integer}
 end

--- a/test/stream_data/types_test.exs
+++ b/test/stream_data/types_test.exs
@@ -1341,6 +1341,24 @@ defmodule StreamData.TypesTest do
     check all y <- term(), do: refute(member.(y))
   end
 
+  test "type with names" do
+    {generator, member} = generate_data(:named_colour)
+
+    check all colour <- generator,
+              y <- term(),
+              !(is_tuple(y) && tuple_size(y) == 3),
+              max_runs: 25 do
+      assert {red, green, blue} = colour
+      assert is_integer(red)
+      assert is_integer(green)
+      assert is_integer(blue)
+      assert member.(colour)
+      refute member.(y)
+    end
+  end
+
+  ## Helpers
+
   defp is_forest({x, forests}) when is_integer(x) and is_list(forests) do
     Enum.all?(forests, &is_forest/1)
   end

--- a/test/stream_data/validations_test.exs
+++ b/test/stream_data/validations_test.exs
@@ -29,28 +29,27 @@ defmodule StreamData.ValidationsTest do
     end
 
     test "catches functions without no_return" do
-      assert {:error, [%{original_failure: :unspecified_no_return}]} = validate(Functions, :test_missing_no_return, 1)
+      assert {:error, [%{original_failure: :unspecified_no_return}]} =
+               validate(Functions, :test_missing_no_return, 1)
     end
 
     test "catches functions with wrong return type" do
-      assert {:error, [%{original_failure: {_args, return}}]} = validate(Functions, :test_wrong_return, 1)
+      assert {:error, [%{original_failure: {_args, return}}]} =
+               validate(Functions, :test_wrong_return, 1)
+
       assert :foo = return
     end
   end
 
   test "missing function spec" do
-    assert_raise(
-      ArgumentError,
-      ~r/Missing type specification for function/,
-      fn -> validate(Functions, :does_not_exist, 0) end
-    )
+    assert_raise(ArgumentError, ~r/Missing type specification for function/, fn ->
+      validate(Functions, :does_not_exist, 0)
+    end)
   end
 
   test "missing module" do
-    assert_raise(
-      ArgumentError,
-      ~r/Could not find .beam file for/,
-      fn -> validate(DoesNotExist, :function, 1) end
-    )
+    assert_raise(ArgumentError, ~r/Could not find .beam file for/, fn ->
+      validate(DoesNotExist, :function, 1)
+    end)
   end
 end

--- a/test/stream_data/validations_test.exs
+++ b/test/stream_data/validations_test.exs
@@ -1,0 +1,56 @@
+defmodule StreamData.ValidationsTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  import StreamDataTypes
+  alias StreamDataTest.Functions
+
+  describe "function validation" do
+    test "simple functions" do
+      assert {:ok, _} = validate(Kernel, :is_integer, 1)
+    end
+
+    test "passes when function has no_return" do
+      assert {:ok, _} = validate(Functions, :test_no_return, 1)
+    end
+
+    test "type names" do
+      assert {:ok, _} = validate(Functions, :test_names, 3)
+    end
+
+    test "type guards" do
+      assert {:ok, _} = validate(Functions, :test_guards, 1)
+      assert {:ok, _} = validate(Functions, :test_multiple_guards, 3)
+    end
+
+    test "overloaded specs" do
+      assert {:ok, results} = validate(Functions, :test_overloaded_spec, 1)
+      assert length(results) == 2
+    end
+
+    test "catches functions without no_return" do
+      assert {:error, [%{original_failure: :unspecified_no_return}]} = validate(Functions, :test_missing_no_return, 1)
+    end
+
+    test "catches functions with wrong return type" do
+      assert {:error, [%{original_failure: {_args, return}}]} = validate(Functions, :test_wrong_return, 1)
+      assert :foo = return
+    end
+  end
+
+  test "missing function spec" do
+    assert_raise(
+      ArgumentError,
+      ~r/Missing type specification for function/,
+      fn -> validate(Functions, :does_not_exist, 0) end
+    )
+  end
+
+  test "missing module" do
+    assert_raise(
+      ArgumentError,
+      ~r/Could not find .beam file for/,
+      fn -> validate(DoesNotExist, :function, 1) end
+    )
+  end
+end

--- a/test/stream_data/validations_test.exs
+++ b/test/stream_data/validations_test.exs
@@ -55,6 +55,10 @@ defmodule StreamData.ValidationsTest do
     test "nested user types" do
       assert {:ok, _} = validate(Functions, :test_nested_user_types, 1)
     end
+
+    test "catches wrong no return" do
+      assert {:error, [%{original_failure: :no_return_specified}]} = validate(Functions, :test_wrong_no_return, 1)
+    end
   end
 
   test "missing function spec" do

--- a/test/stream_data/validations_test.exs
+++ b/test/stream_data/validations_test.exs
@@ -44,6 +44,18 @@ defmodule StreamData.ValidationsTest do
       assert {:ok, results} = validate(Functions, :test_overloaded_with_var, 2)
       assert length(results) == 2
     end
+
+    test "argument with type variable" do
+      assert {:ok, _} = validate(Functions, :test_type_variable, 1)
+    end
+
+    test "arguments with remote types" do
+      assert {:ok, _} = validate(Functions, :test_remote_type, 1)
+    end
+
+    test "nested user types" do
+      assert {:ok, _} = validate(Functions, :test_nested_user_types, 1)
+    end
   end
 
   test "missing function spec" do

--- a/test/stream_data/validations_test.exs
+++ b/test/stream_data/validations_test.exs
@@ -28,9 +28,8 @@ defmodule StreamData.ValidationsTest do
       assert length(results) == 2
     end
 
-    test "catches functions without no_return" do
-      assert {:error, [%{original_failure: :unspecified_no_return}]} =
-               validate(Functions, :test_missing_no_return, 1)
+    test "catches functions that error out sometimes" do
+      assert {:ok, _} = validate(Functions, :test_sometime_raise, 1)
     end
 
     test "catches functions with wrong return type" do

--- a/test/stream_data/validations_test.exs
+++ b/test/stream_data/validations_test.exs
@@ -39,6 +39,11 @@ defmodule StreamData.ValidationsTest do
 
       assert :foo = return
     end
+
+    test "overloaded with variables" do
+      assert {:ok, results} = validate(Functions, :test_overloaded_with_var, 2)
+      assert length(results) == 2
+    end
   end
 
   test "missing function spec" do


### PR DESCRIPTION
The function validation API checks whether a function matches it's
defined type specification.

High level overview of how the validation API works:
  1. Read the function spec
  2. Create a generator for the specified arguments
  3. Create a member function for the specified return type
  4. Apply arguments to the function and check that the result belongs
  to the member.
  5. Rescue function failure and return result based on whether the type
  has `:no_return` or `:none`

To do this there is some preparatory work
  - users can name their variables - this is inlined
  - functions with bound variables - also inlined
  - overloaded functions - overloaded functions are tested for every
  overloaded definition there is(the high level overview is  basically
  done for every function definition) - afterwards results are
  aggregated - this could be changed to be better I believe
  - raise when spec/module not found

The current aggregation being done is simple:
  - if all function overloads pass, return {:ok, [list of metadata]}
  - else: {:error, [list of only the failing metadata results]}